### PR TITLE
feat: remove Node.js v10 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-    labels:
-      - ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [12, 14, 16]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}
@@ -21,7 +21,6 @@ jobs:
       uses: bahmutov/npm-install@v1.7.7
       with:
         useLockFile: false
-    - name: npm ls
-      run: npm ls
+    - run: npm ls
     - name: Test
       run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 12
+          node-version: 14
       - name: Update npm
         run: |
           npm install -g npm

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2014-2016 Kenan Yildirim <http://kenany.me/>
+Copyright 2014-2021 Kenan Yildirim <https://kenany.me/>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": "KenanY/find-prime",
   "license": "MIT",
-  "author": "Kenan Yildirim <kenan@kenany.me> (http://kenany.me/)",
+  "author": "Kenan Yildirim <kenan@kenany.me> (https://kenany.me/)",
   "main": "index.js",
   "files": [
     "index.js",
@@ -18,7 +18,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "10 || 12 || >=14"
+    "node": "12 || 14 || >=16"
   },
   "scripts": {
     "example": "browserify example/workers/index.js > example/workers/bundle.js",
@@ -42,11 +42,11 @@
     "browserify": "^17.0.0",
     "conventional-changelog-conventionalcommits": "^4.6.0",
     "eslint": "^7.28.0",
-    "estimate-cores": "1.0.2",
-    "global": "4.4.0",
-    "mercury": "14.2.0",
+    "estimate-cores": "^1.0.2",
+    "global": "^4.4.0",
+    "mercury": "^14.2.0",
     "semantic-release": "^17.4.3",
-    "tape": "5.2.2",
-    "webworkify": "1.5.0"
+    "tape": "^5.2.2",
+    "webworkify": "^1.5.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported. The minimum
supported version of Node.js is now v12.