### PR TITLE
feat: drop Node.js v12 support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["local>kenany/renovate-config"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>kenany/renovate-config"],
+  "assignees": ["kenany"],
+  "reviewers": ["kenany"]
 }

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "12 || 14 || >=16"
+    "node": "14 || 16 || >=18"
   },
   "scripts": {
     "example": "browserify example/workers/index.js > example/workers/bundle.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v12 is no longer supported.